### PR TITLE
Update from last released ua-charm

### DIFF
--- a/charmcraft-22.04.yaml
+++ b/charmcraft-22.04.yaml
@@ -1,0 +1,17 @@
+# This file configures Charmcraft.
+# See https://juju.is/docs/sdk/charmcraft-config for guidance.
+
+type: charm
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "16.04"
+    - name: ubuntu
+      channel: "18.04"
+    - name: ubuntu
+      channel: "20.04"
+    - name: ubuntu
+      channel: "22.04"

--- a/charmcraft-24.04.yaml
+++ b/charmcraft-24.04.yaml
@@ -1,0 +1,6 @@
+type: charm
+
+base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,17 +1,1 @@
-# This file configures Charmcraft.
-# See https://juju.is/docs/sdk/charmcraft-config for guidance.
-
-type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "16.04"
-    - name: ubuntu
-      channel: "18.04"
-    - name: ubuntu
-      channel: "20.04"
-    - name: ubuntu
-      channel: "22.04"
+charmcraft-22.04.yaml

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,3 +15,5 @@ bases:
       channel: "20.04"
     - name: ubuntu
       channel: "22.04"
+    - name: ubuntu
+      channel: "24.04"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,5 +15,3 @@ bases:
       channel: "20.04"
     - name: ubuntu
       channel: "22.04"
-    - name: ubuntu
-      channel: "24.04"

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,10 @@ options:
     default: ""
     description: https-proxy which can override juju https-proxy
     type: string
+  override-ssl-cert-file:
+    default: ""
+    description: Path to a custom SSL certificate file to use for the Ubuntu Pro client actions.
+    type: string
   livepatch_server_url:
     default: ""
     description: URL of the livepatch on-prem server. Unsetting will revert the on-prem server to the default server (https://livepatch.canonical.com).

--- a/config.yaml
+++ b/config.yaml
@@ -24,3 +24,19 @@ options:
     default: ""
     description: https-proxy which can override juju https-proxy
     type: string
+  livepatch_server_url:
+    default: ""
+    description: URL of the livepatch on-prem server. Unsetting will revert the on-prem server to the default server (https://livepatch.canonical.com).
+    type: string
+  livepatch_token:
+    default: ""
+    description:
+      Authorization token for the livepatch on-prem server. Required if livepatch_server_url is set.
+      Unsetting will revert the on-prem server to the default server (https://livepatch.canonical.com).
+    type: string
+  services:
+    default: ""
+    description:
+      A comma-separated list of services to enable when attaching to a pro subscription. This list overrides the default services. If specified, only these services will be activated. If left empty, the default services are activated.
+      A list of possible services can be found by running "pro status --all" on a machine with the ubuntu-pro-client package installed.
+    type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,6 +6,7 @@ series:
   - bionic
   - xenial
   - jammy
+  - noble
 subordinate: true
 requires:
   juju-info:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,7 +6,6 @@ series:
   - bionic
   - xenial
   - jammy
-  - noble
 subordinate: true
 requires:
   juju-info:

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,23 +58,43 @@ def set_livepatch_server(server):
     logger.info("Setting livepatch on-prem server")
     result = subprocess.run(
         ["canonical-livepatch", "config", f"remote-server={server}"],
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
-        logger.error("Error setting canonical-livepatch server: %s", result.stderr)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error setting canonical-livepatch server: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 def enable_livepatch_server(token):
     """Enable livepatch with the specified token."""
     logger.info("Enabling livepatch on-prem server using auth token")
     result = subprocess.run(
-        ["canonical-livepatch", "enable", token], capture_output=True, text=True
+        ["canonical-livepatch", "enable", token], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     if result.returncode != 0:
-        logger.error("Error running canonical-livepatch enable: %s", result.stderr)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running canonical-livepatch enable: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 def install_livepatch():
@@ -85,10 +105,22 @@ def install_livepatch():
 
 def disable_canonical_livepatch():
     """Disable the canonical-livepatch."""
-    result = subprocess.run(["canonical-livepatch", "disable"], capture_output=True, text=True)
+    result = subprocess.run(
+        ["canonical-livepatch", "disable"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     if result.returncode != 0:
-        logger.error("Error running canonical-livepatch disable: %s", result.stderr)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running canonical-livepatch disable: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 def ua_enable_service(service):
@@ -127,27 +159,49 @@ def attach_subscription(token, services=None):
         with create_attach_config(token, services) as attach_config_path:
             result = subprocess.run(
                 ["ubuntu-advantage", "attach", "--attach-config", attach_config_path],
-                capture_output=True,
-                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
     else:
         result = subprocess.run(
-            ["ubuntu-advantage", "attach", token], capture_output=True, text=True
+            ["ubuntu-advantage", "attach", token], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
     if result.returncode != 0:
-        logger.error("Error running attach. stderr %s\nstdout: %s", result.stderr, result.stdout)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running attach. stderr %s\nstdout: %s", stderr, stdout)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 @retry(ProcessExecutionError)
 def get_status_output():
     """Return the parsed output from ubuntu-advantage status."""
     result = subprocess.run(
-        ["ubuntu-advantage", "status", "--all", "--format", "json"], capture_output=True, text=True
+        ["ubuntu-advantage", "status", "--all", "--format", "json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
-        logger.error("Error running attach. stderr %s\nstdout: %s", result.stderr, result.stdout)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running status. stderr %s\nstdout: %s", stderr, stdout)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
     output = result.stdout
     # handle different return type from xenial
     if isinstance(output, bytes):

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,10 +47,10 @@ def update_configuration(contract_url):
         f.truncate()
 
 
-def detach_subscription():
+def detach_subscription(env):
     """Detach from any ubuntu-advantage subscription."""
     logger.info("Detaching ubuntu-advantage subscription")
-    subprocess.check_call(["ubuntu-advantage", "detach", "--assume-yes"])
+    subprocess.check_call(["ubuntu-advantage", "detach", "--assume-yes"], env=env)
 
 
 def set_livepatch_server(server):
@@ -123,9 +123,9 @@ def disable_canonical_livepatch():
         raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
-def ua_enable_service(service):
+def ua_enable_service(service, env):
     """Enable a ubuntu-advantage service."""
-    subprocess.check_call(["ubuntu-advantage", "enable", service])
+    subprocess.check_call(["ubuntu-advantage", "enable", service], env=env)
 
 
 def parse_services(services_str):
@@ -153,7 +153,7 @@ def create_attach_config(token, services=None):
 
 
 @retry(ProcessExecutionError)
-def attach_subscription(token, services=None):
+def attach_subscription(token, env, services=None):
     """Attach an ubuntu-advantage subscription using the specified token and services."""
     if services:
         with create_attach_config(token, services) as attach_config_path:
@@ -161,10 +161,14 @@ def attach_subscription(token, services=None):
                 ["ubuntu-advantage", "attach", "--attach-config", attach_config_path],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                env=env,
             )
     else:
         result = subprocess.run(
-            ["ubuntu-advantage", "attach", token], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ["ubuntu-advantage", "attach", token],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
         )
     if result.returncode != 0:
         stdout = (
@@ -182,12 +186,13 @@ def attach_subscription(token, services=None):
 
 
 @retry(ProcessExecutionError)
-def get_status_output():
+def get_status_output(env):
     """Return the parsed output from ubuntu-advantage status."""
     result = subprocess.run(
         ["ubuntu-advantage", "status", "--all", "--format", "json"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
     )
     if result.returncode != 0:
         stdout = (
@@ -226,6 +231,7 @@ class UbuntuAdvantageCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self._setup_proxy_env()
+        self._setup_ssl_env()
         self._state.set_default(
             contract_url=None,
             hashed_token=None,
@@ -239,14 +245,14 @@ class UbuntuAdvantageCharm(CharmBase):
 
     def _setup_proxy_env(self):
         """Setup proxy variables from model."""
-        self.env = dict(os.environ)
-        self.env["http_proxy"] = self.config.get("override-http-proxy") or self.env.get(
-            "JUJU_CHARM_HTTP_PROXY", ""
-        )
-        self.env["https_proxy"] = self.config.get("override-https-proxy") or self.env.get(
-            "JUJU_CHARM_HTTPS_PROXY", ""
-        )
-        self.env["no_proxy"] = self.env.get("JUJU_CHARM_NO_PROXY", "")
+        self.proxy_env = dict(os.environ)
+        self.proxy_env["http_proxy"] = self.config.get(
+            "override-http-proxy"
+        ) or self.proxy_env.get("JUJU_CHARM_HTTP_PROXY", "")
+        self.proxy_env["https_proxy"] = self.config.get(
+            "override-https-proxy"
+        ) or self.proxy_env.get("JUJU_CHARM_HTTPS_PROXY", "")
+        self.proxy_env["no_proxy"] = self.proxy_env.get("JUJU_CHARM_NO_PROXY", "")
 
         # The values for 'http_proxy' and 'https_proxy' will be used for the
         # PPA install/remove operations (passed as environment variables), as
@@ -255,15 +261,23 @@ class UbuntuAdvantageCharm(CharmBase):
         # operations (passed as an environment variable).
 
         # log proxy environment variables for debugging
-        for envvar, value in self.env.items():
+        for envvar, value in self.proxy_env.items():
             if envvar.endswith("proxy".lower()):
                 logger.debug("Envvar '%s' => '%s'", envvar, value)
+
+    def _setup_ssl_env(self):
+        """Setup openssl variables from model."""
+        self.ssl_env = dict(os.environ)
+        value = self.config.get("override-ssl-cert-file", "")
+        self.ssl_env["SSL_CERT_FILE"] = value
+        logger.debug("Envvar 'SSL_CERT_FILE' => '%s'", value)
 
     def config_changed(self, event):
         """Install and configure ubuntu-advantage tools and attachment."""
         logger.info("Beginning config_changed")
         self.unit.status = MaintenanceStatus("Configuring")
         self._setup_proxy_env()
+        self._setup_ssl_env()
         self._handle_ppa_state()
         self._handle_package_state()
         self._configure_livepatch()
@@ -282,14 +296,14 @@ class UbuntuAdvantageCharm(CharmBase):
 
         if old_ppa and old_ppa != ppa:
             logger.info("Removing previously installed ppa (%s)", old_ppa)
-            remove_ppa(old_ppa, self.env)
+            remove_ppa(old_ppa, self.proxy_env)
             self._state.ppa = None
             # If ppa is changed, want to remove the previous version of the package for consistency
             self._state.package_needs_installing = True
 
         if ppa and ppa != old_ppa:
             logger.info("Installing ppa: %s", ppa)
-            install_ppa(ppa, self.env)
+            install_ppa(ppa, self.proxy_env)
             self._state.ppa = ppa
             # If ppa is changed, want to force an install of the package for potential updates
             self._state.package_needs_installing = True
@@ -321,7 +335,7 @@ class UbuntuAdvantageCharm(CharmBase):
                 self._state.livepatch_installed and self._state.hashed_livepatch_token is not None
             ):
                 # Set to default server
-                status = get_status_output()
+                status = get_status_output(self.ssl_env)
                 is_attached = status.get("attached")
                 enabled_services = get_enabled_services(status)
                 logger.info("Setting livepatch on-prem server to default")
@@ -330,7 +344,7 @@ class UbuntuAdvantageCharm(CharmBase):
                 disable_canonical_livepatch()
                 if is_attached and "livepatch" in enabled_services:
                     logger.info("Enabling livepatch hosted server using Pro client")
-                    ua_enable_service("livepatch")
+                    ua_enable_service("livepatch", self.ssl_env)
                 self._state.hashed_livepatch_token = None
         except ProcessExecutionError as e:
             logger.error("Failed to configure livepatch: %s", str(e))
@@ -358,12 +372,12 @@ class UbuntuAdvantageCharm(CharmBase):
             self._state.contract_url = contract_url
 
         try:
-            status = get_status_output()
+            status = get_status_output(self.ssl_env)
         except ProcessExecutionError as e:
             self.unit.status = BlockedStatus(str(e))
             return
         if status["attached"] and (config_changed or token_changed):
-            detach_subscription()
+            detach_subscription(self.ssl_env)
             self._state.hashed_token = None
 
         if not token:
@@ -373,7 +387,7 @@ class UbuntuAdvantageCharm(CharmBase):
             logger.info("Attaching ubuntu-advantage subscription")
             try:
                 enable_services = parse_services(self.config.get("services", "").strip())
-                attach_subscription(token, services=enable_services)
+                attach_subscription(token, self.ssl_env, services=enable_services)
             except ProcessExecutionError as e:
                 self.unit.status = BlockedStatus(str(e))
                 return
@@ -381,7 +395,7 @@ class UbuntuAdvantageCharm(CharmBase):
 
     def _handle_status_state(self):
         """Parse status output to determine which services are active."""
-        status = get_status_output()
+        status = get_status_output(self.ssl_env)
         services = get_enabled_services(status)
         message = "Attached (" + ",".join(services) + ")"
         self.unit.status = ActiveStatus(message)
@@ -389,13 +403,13 @@ class UbuntuAdvantageCharm(CharmBase):
     def _configure_ua_proxy(self):
         """Configure the proxy options for the ubuntu-advantage client."""
         for config_key in ("http_proxy", "https_proxy"):
-            if self.env[config_key]:
+            if self.proxy_env[config_key]:
                 subprocess.check_call(
                     [
                         "ubuntu-advantage",
                         "config",
                         "set",
-                        "{}={}".format(config_key, self.env[config_key]),
+                        "{}={}".format(config_key, self.proxy_env[config_key]),
                     ]
                 )
             else:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,8 +33,11 @@ async def test_attach_invalid_token(ops_test: OpsTest):
     await charm.set_config({"token": "new-token-2"})
     await ops_test.model.wait_for_idle()
 
+    expected_error = "Failed running command '['ubuntu-advantage', 'attach', 'new-token-2']' \
+[exit status: 1].\nstderr: Invalid token. See https://ubuntu.com/pro/dashboard\n\nstdout: "
     unit = charm.units[0]
     assert unit.workload_status == BlockedStatus.name
+    assert unit.workload_status_message == expected_error
 
 
 async def test_attach_services(ops_test: OpsTest):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import os
+
 import pytest
 from ops.model import ActiveStatus, BlockedStatus
 from pytest_operator.plugin import OpsTest
@@ -29,6 +31,84 @@ async def test_attach_invalid_token(ops_test: OpsTest):
     await ops_test.model.wait_for_idle()
 
     await charm.set_config({"token": "new-token-2"})
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_attach_services(ops_test: OpsTest):
+    # Set test token to environment variable PRO_CHARM_TEST_TOKEN
+    # bash: export PRO_CHARM_TEST_TOKEN="your-token"
+    test_token = os.environ.get("PRO_CHARM_TEST_TOKEN")
+    charm = ops_test.model.applications["ubuntu-advantage"]
+
+    # Attach to pro subscription with services
+    await charm.set_config({"services": "esm-infra,cis", "token": f"{test_token}"})
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == ActiveStatus.name
+    assert unit.workload_status_message == "Attached (esm-infra,usg)"
+
+    # Detach from pro subscription
+    await charm.set_config({"token": "", "services": ""})
+    await ops_test.model.wait_for_idle()
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_empty_livepatch_config(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    test_token = os.environ.get("PRO_CHARM_TEST_TOKEN")
+
+    await charm.set_config({"token": test_token, "livepatch_token": ""})
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == ActiveStatus.name
+
+    # Detach from pro subscription
+    await charm.set_config({"token": ""})
+    await ops_test.model.wait_for_idle()
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_livepatch_server_success(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    test_pro_token = os.environ.get("PRO_CHARM_TEST_TOKEN")
+    test_livepatch_token = os.environ.get("PRO_CHARM_TEST_LIVEPATCH_STAGING_TOKEN")
+
+    await charm.set_config(
+        {
+            "livepatch_server_url": "https://livepatch.staging.canonical.com",
+            "livepatch_token": test_livepatch_token,
+            "token": test_pro_token,
+        }
+    )
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == ActiveStatus.name
+
+    # Detach from pro subscription and livepatch
+    await charm.set_config({"token": "", "livepatch_token": "", "livepatch_server_url": ""})
+    await ops_test.model.wait_for_idle()
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_livepatch_server_set_fails(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    await charm.set_config(
+        {"livepatch_server_url": "https://www.example.com", "livepatch_token": "new-token"}
+    )
+    await ops_test.model.wait_for_idle()
+    unit = charm.units[0]
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_detach_subscription(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    await charm.set_config({"token": ""})
     await ops_test.model.wait_for_idle()
 
     unit = charm.units[0]

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ passenv =
   HTTP_PROXY
   HTTPS_PROXY
   NO_PROXY
+  PRO_CHARM_TEST_TOKEN
+  PRO_CHARM_TEST_LIVEPATCH_STAGING_TOKEN
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/tox.ini
+++ b/tox.ini
@@ -72,9 +72,16 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju>=3.5.2.0
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+
+[testenv:pack-24.04]
+description = Link charmcraft-24.04.yaml to charmcraft.yaml, pack and restore
+allowlist_externals =
+    sh
+commands =
+    sh -c "ln -srf {toxinidir}/charmcraft-24.04.yaml {toxinidir}/charmcraft.yaml && charmcraft pack --project-dir={toxinidir}; ln -srf {toxinidir}/charmcraft-22.04.yaml {toxinidir}/charmcraft.yaml"


### PR DESCRIPTION
The proposed changes contain all the new bug fixes and updates from the ubuntu-advantage-charm on Launchpad to make this charm up to date with the latest release of the ua-charm.

This also marks the deprecation of the ubuntu-advantage charm as development will now to move to this GH repository and all future charm updates will be released through the ubuntu-pro charm linked to this CharmHub charm -  https://charmhub.io/ubuntu-pro.