### PR TITLE
Add pro-client api to charm operator

### DIFF
--- a/charmcraft-22.04.yaml
+++ b/charmcraft-22.04.yaml
@@ -1,0 +1,17 @@
+# This file configures Charmcraft.
+# See https://juju.is/docs/sdk/charmcraft-config for guidance.
+
+type: charm
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "16.04"
+    - name: ubuntu
+      channel: "18.04"
+    - name: ubuntu
+      channel: "20.04"
+    - name: ubuntu
+      channel: "22.04"

--- a/charmcraft-24.04.yaml
+++ b/charmcraft-24.04.yaml
@@ -1,0 +1,6 @@
+type: charm
+
+base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,17 +1,1 @@
-# This file configures Charmcraft.
-# See https://juju.is/docs/sdk/charmcraft-config for guidance.
-
-type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-    run-on:
-    - name: ubuntu
-      channel: "16.04"
-    - name: ubuntu
-      channel: "18.04"
-    - name: ubuntu
-      channel: "20.04"
-    - name: ubuntu
-      channel: "22.04"
+charmcraft-22.04.yaml

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,3 +15,5 @@ bases:
       channel: "20.04"
     - name: ubuntu
       channel: "22.04"
+    - name: ubuntu
+      channel: "24.04"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,5 +15,3 @@ bases:
       channel: "20.04"
     - name: ubuntu
       channel: "22.04"
-    - name: ubuntu
-      channel: "24.04"

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,10 @@ options:
     default: ""
     description: https-proxy which can override juju https-proxy
     type: string
+  override-ssl-cert-file:
+    default: ""
+    description: Path to a custom SSL certificate file to use for the Ubuntu Pro client actions.
+    type: string
   livepatch_server_url:
     default: ""
     description: URL of the livepatch on-prem server. Unsetting will revert the on-prem server to the default server (https://livepatch.canonical.com).

--- a/config.yaml
+++ b/config.yaml
@@ -24,3 +24,19 @@ options:
     default: ""
     description: https-proxy which can override juju https-proxy
     type: string
+  livepatch_server_url:
+    default: ""
+    description: URL of the livepatch on-prem server. Unsetting will revert the on-prem server to the default server (https://livepatch.canonical.com).
+    type: string
+  livepatch_token:
+    default: ""
+    description:
+      Authorization token for the livepatch on-prem server. Required if livepatch_server_url is set.
+      Unsetting will revert the on-prem server to the default server (https://livepatch.canonical.com).
+    type: string
+  services:
+    default: ""
+    description:
+      A comma-separated list of services to enable when attaching to a pro subscription. This list overrides the default services. If specified, only these services will be activated. If left empty, the default services are activated.
+      A list of possible services can be found by running "pro status --all" on a machine with the ubuntu-pro-client package installed.
+    type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,6 +6,7 @@ series:
   - bionic
   - xenial
   - jammy
+  - noble
 subordinate: true
 requires:
   juju-info:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,7 +6,6 @@ series:
   - bionic
   - xenial
   - jammy
-  - noble
 subordinate: true
 requires:
   juju-info:

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,23 +58,43 @@ def set_livepatch_server(server):
     logger.info("Setting livepatch on-prem server")
     result = subprocess.run(
         ["canonical-livepatch", "config", f"remote-server={server}"],
-        capture_output=True,
-        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
-        logger.error("Error setting canonical-livepatch server: %s", result.stderr)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error setting canonical-livepatch server: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 def enable_livepatch_server(token):
     """Enable livepatch with the specified token."""
     logger.info("Enabling livepatch on-prem server using auth token")
     result = subprocess.run(
-        ["canonical-livepatch", "enable", token], capture_output=True, text=True
+        ["canonical-livepatch", "enable", token], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     if result.returncode != 0:
-        logger.error("Error running canonical-livepatch enable: %s", result.stderr)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running canonical-livepatch enable: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 def install_livepatch():
@@ -85,10 +105,22 @@ def install_livepatch():
 
 def disable_canonical_livepatch():
     """Disable the canonical-livepatch."""
-    result = subprocess.run(["canonical-livepatch", "disable"], capture_output=True, text=True)
+    result = subprocess.run(
+        ["canonical-livepatch", "disable"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     if result.returncode != 0:
-        logger.error("Error running canonical-livepatch disable: %s", result.stderr)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running canonical-livepatch disable: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 def ua_enable_service(service):
@@ -127,27 +159,49 @@ def attach_subscription(token, services=None):
         with create_attach_config(token, services) as attach_config_path:
             result = subprocess.run(
                 ["ubuntu-advantage", "attach", "--attach-config", attach_config_path],
-                capture_output=True,
-                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
     else:
         result = subprocess.run(
-            ["ubuntu-advantage", "attach", token], capture_output=True, text=True
+            ["ubuntu-advantage", "attach", token], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
     if result.returncode != 0:
-        logger.error("Error running attach. stderr %s\nstdout: %s", result.stderr, result.stdout)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running attach. stderr %s\nstdout: %s", stderr, stdout)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
 @retry(ProcessExecutionError)
 def get_status_output():
     """Return the parsed output from ubuntu-advantage status."""
     result = subprocess.run(
-        ["ubuntu-advantage", "status", "--all", "--format", "json"], capture_output=True, text=True
+        ["ubuntu-advantage", "status", "--all", "--format", "json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
-        logger.error("Error running attach. stderr %s\nstdout: %s", result.stderr, result.stdout)
-        raise ProcessExecutionError(result.args, result.returncode, result.stdout, result.stderr)
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running status. stderr %s\nstdout: %s", stderr, stdout)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
     output = result.stdout
     # handle different return type from xenial
     if isinstance(output, bytes):

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,10 +47,10 @@ def update_configuration(contract_url):
         f.truncate()
 
 
-def detach_subscription():
+def detach_subscription(env):
     """Detach from any ubuntu-advantage subscription."""
     logger.info("Detaching ubuntu-advantage subscription")
-    subprocess.check_call(["ubuntu-advantage", "detach", "--assume-yes"])
+    subprocess.check_call(["ubuntu-advantage", "detach", "--assume-yes"], env=env)
 
 
 def set_livepatch_server(server):
@@ -123,9 +123,9 @@ def disable_canonical_livepatch():
         raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
 
 
-def ua_enable_service(service):
+def ua_enable_service(service, env):
     """Enable a ubuntu-advantage service."""
-    subprocess.check_call(["ubuntu-advantage", "enable", service])
+    subprocess.check_call(["ubuntu-advantage", "enable", service], env=env)
 
 
 def parse_services(services_str):
@@ -153,7 +153,7 @@ def create_attach_config(token, services=None):
 
 
 @retry(ProcessExecutionError)
-def attach_subscription(token, services=None):
+def attach_subscription(token, env, services=None):
     """Attach an ubuntu-advantage subscription using the specified token and services."""
     if services:
         with create_attach_config(token, services) as attach_config_path:
@@ -161,10 +161,14 @@ def attach_subscription(token, services=None):
                 ["ubuntu-advantage", "attach", "--attach-config", attach_config_path],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                env=env,
             )
     else:
         result = subprocess.run(
-            ["ubuntu-advantage", "attach", token], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ["ubuntu-advantage", "attach", token],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
         )
     if result.returncode != 0:
         stdout = (
@@ -182,12 +186,13 @@ def attach_subscription(token, services=None):
 
 
 @retry(ProcessExecutionError)
-def get_status_output():
+def get_status_output(env):
     """Return the parsed output from ubuntu-advantage status."""
     result = subprocess.run(
         ["ubuntu-advantage", "status", "--all", "--format", "json"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
     )
     if result.returncode != 0:
         stdout = (
@@ -226,6 +231,7 @@ class UbuntuAdvantageCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self._setup_proxy_env()
+        self._setup_ssl_env()
         self._state.set_default(
             contract_url=None,
             hashed_token=None,
@@ -239,14 +245,14 @@ class UbuntuAdvantageCharm(CharmBase):
 
     def _setup_proxy_env(self):
         """Setup proxy variables from model."""
-        self.env = dict(os.environ)
-        self.env["http_proxy"] = self.config.get("override-http-proxy") or self.env.get(
-            "JUJU_CHARM_HTTP_PROXY", ""
-        )
-        self.env["https_proxy"] = self.config.get("override-https-proxy") or self.env.get(
-            "JUJU_CHARM_HTTPS_PROXY", ""
-        )
-        self.env["no_proxy"] = self.env.get("JUJU_CHARM_NO_PROXY", "")
+        self.proxy_env = dict(os.environ)
+        self.proxy_env["http_proxy"] = self.config.get(
+            "override-http-proxy"
+        ) or self.proxy_env.get("JUJU_CHARM_HTTP_PROXY", "")
+        self.proxy_env["https_proxy"] = self.config.get(
+            "override-https-proxy"
+        ) or self.proxy_env.get("JUJU_CHARM_HTTPS_PROXY", "")
+        self.proxy_env["no_proxy"] = self.proxy_env.get("JUJU_CHARM_NO_PROXY", "")
 
         # The values for 'http_proxy' and 'https_proxy' will be used for the
         # PPA install/remove operations (passed as environment variables), as
@@ -255,15 +261,23 @@ class UbuntuAdvantageCharm(CharmBase):
         # operations (passed as an environment variable).
 
         # log proxy environment variables for debugging
-        for envvar, value in self.env.items():
+        for envvar, value in self.proxy_env.items():
             if envvar.endswith("proxy".lower()):
                 logger.debug("Envvar '%s' => '%s'", envvar, value)
+
+    def _setup_ssl_env(self):
+        """Setup openssl variables from model."""
+        self.ssl_env = dict(os.environ)
+        value = self.config.get("override-ssl-cert-file", "")
+        self.ssl_env["SSL_CERT_FILE"] = value
+        logger.debug("Envvar 'SSL_CERT_FILE' => '%s'", value)
 
     def config_changed(self, event):
         """Install and configure ubuntu-advantage tools and attachment."""
         logger.info("Beginning config_changed")
         self.unit.status = MaintenanceStatus("Configuring")
         self._setup_proxy_env()
+        self._setup_ssl_env()
         self._handle_ppa_state()
         self._handle_package_state()
         self._configure_livepatch()
@@ -282,14 +296,14 @@ class UbuntuAdvantageCharm(CharmBase):
 
         if old_ppa and old_ppa != ppa:
             logger.info("Removing previously installed ppa (%s)", old_ppa)
-            remove_ppa(old_ppa, self.env)
+            remove_ppa(old_ppa, self.proxy_env)
             self._state.ppa = None
             # If ppa is changed, want to remove the previous version of the package for consistency
             self._state.package_needs_installing = True
 
         if ppa and ppa != old_ppa:
             logger.info("Installing ppa: %s", ppa)
-            install_ppa(ppa, self.env)
+            install_ppa(ppa, self.proxy_env)
             self._state.ppa = ppa
             # If ppa is changed, want to force an install of the package for potential updates
             self._state.package_needs_installing = True
@@ -321,7 +335,7 @@ class UbuntuAdvantageCharm(CharmBase):
                 self._state.livepatch_installed and self._state.hashed_livepatch_token is not None
             ):
                 # Set to default server
-                status = get_status_output()
+                status = get_status_output(self.ssl_env)
                 is_attached = status.get("attached")
                 enabled_services = get_enabled_services(status)
                 logger.info("Setting livepatch on-prem server to default")
@@ -330,7 +344,7 @@ class UbuntuAdvantageCharm(CharmBase):
                 disable_canonical_livepatch()
                 if is_attached and "livepatch" in enabled_services:
                     logger.info("Enabling livepatch hosted server using Pro client")
-                    ua_enable_service("livepatch")
+                    ua_enable_service("livepatch", self.ssl_env)
                 self._state.hashed_livepatch_token = None
         except ProcessExecutionError as e:
             logger.error("Failed to configure livepatch: %s", str(e))
@@ -358,12 +372,12 @@ class UbuntuAdvantageCharm(CharmBase):
             self._state.contract_url = contract_url
 
         try:
-            status = get_status_output()
+            status = get_status_output(self.ssl_env)
         except ProcessExecutionError as e:
             self.unit.status = BlockedStatus(str(e))
             return
         if status["attached"] and (config_changed or token_changed):
-            detach_subscription()
+            detach_subscription(self.ssl_env)
             self._state.hashed_token = None
 
         if not token:
@@ -373,7 +387,7 @@ class UbuntuAdvantageCharm(CharmBase):
             logger.info("Attaching ubuntu-advantage subscription")
             try:
                 enable_services = parse_services(self.config.get("services", "").strip())
-                attach_subscription(token, services=enable_services)
+                attach_subscription(token, self.ssl_env, services=enable_services)
             except ProcessExecutionError as e:
                 self.unit.status = BlockedStatus(str(e))
                 return
@@ -381,7 +395,7 @@ class UbuntuAdvantageCharm(CharmBase):
 
     def _handle_status_state(self):
         """Parse status output to determine which services are active."""
-        status = get_status_output()
+        status = get_status_output(self.ssl_env)
         services = get_enabled_services(status)
         message = "Attached (" + ",".join(services) + ")"
         self.unit.status = ActiveStatus(message)
@@ -389,13 +403,13 @@ class UbuntuAdvantageCharm(CharmBase):
     def _configure_ua_proxy(self):
         """Configure the proxy options for the ubuntu-advantage client."""
         for config_key in ("http_proxy", "https_proxy"):
-            if self.env[config_key]:
+            if self.proxy_env[config_key]:
                 subprocess.check_call(
                     [
                         "ubuntu-advantage",
                         "config",
                         "set",
-                        "{}={}".format(config_key, self.env[config_key]),
+                        "{}={}".format(config_key, self.proxy_env[config_key]),
                     ]
                 )
             else:

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -22,3 +22,18 @@ class ProcessExecutionError(Exception):
         self.stderr = stderr
         message = f"Failed running command '{self.cmd}' [exit status: {self.ret_code}].\nstderr: {self.stderr}\nstdout: {self.stdout}"  # noqa
         super().__init__(message)
+
+
+class APIError(Exception):
+    """Exception raised when there is an error with the Pro Client API.
+
+    Attributes:
+        error_code: The error code returned by the API.
+        message: The error message returned by the API.
+    """
+
+    def __init__(self, error_code: str, message: str):
+        self.error_code = error_code
+        self.message = message
+        message = f"Error code: {self.error_code}, message: {self.message}"
+        super().__init__(message)

--- a/src/livepatch.py
+++ b/src/livepatch.py
@@ -1,12 +1,14 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Canonical livepatch functions."""
+
 import logging
-import os
 import subprocess
 
 from exceptions import ProcessExecutionError
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_LIVEPATCH_SERVER = "https://livepatch.canonical.com"
 
 
 def set_livepatch_server(server):

--- a/src/livepatch.py
+++ b/src/livepatch.py
@@ -1,0 +1,79 @@
+import logging
+import os
+import subprocess
+
+from exceptions import ProcessExecutionError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LIVEPATCH_SERVER = "https://livepatch.canonical.com"
+
+
+def set_livepatch_server(server):
+    """Set the livepatch server."""
+    logger.info("Setting livepatch on-prem server")
+    result = subprocess.run(
+        ["canonical-livepatch", "config", f"remote-server={server}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error setting canonical-livepatch server: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
+
+
+def enable_livepatch_server(token):
+    """Enable livepatch with the specified token."""
+    logger.info("Enabling livepatch on-prem server using auth token")
+    result = subprocess.run(
+        ["canonical-livepatch", "enable", token], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if result.returncode != 0:
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running canonical-livepatch enable: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
+
+
+def install_livepatch():
+    """Install the canonical-livepatch package."""
+    logger.info("Installing package canonical-livepatch")
+    subprocess.check_call(["snap", "install", "canonical-livepatch"])
+
+
+def disable_canonical_livepatch():
+    """Disable the canonical-livepatch."""
+    result = subprocess.run(
+        ["canonical-livepatch", "disable"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if result.returncode != 0:
+        stdout = (
+            result.stdout.decode("utf-8", errors="ignore")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        stderr = (
+            result.stderr.decode("utf-8", errors="ignore")
+            if isinstance(result.stderr, bytes)
+            else result.stderr
+        )
+        logger.error("Error running canonical-livepatch disable: %s", stderr)
+        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)

--- a/src/pro_client.py
+++ b/src/pro_client.py
@@ -1,0 +1,41 @@
+from uaclient.api.u.pro.attach.token.full_token_attach.v1 import (
+    FullTokenAttachOptions,
+    full_token_attach,
+)
+from uaclient.api.u.pro.detach.v1 import detach
+from uaclient.api.u.pro.services.enable.v1 import EnableOptions, enable
+from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
+from uaclient.api.u.pro.status.is_attached.v1 import is_attached
+
+from exceptions import ProcessExecutionError
+from utils import retry
+
+
+# Add error handling to all functions
+def attach_status():
+    return is_attached().is_attached
+
+
+def detach_sub():
+    return detach()
+
+
+def enable_service(service):
+    options = EnableOptions(service=service)
+    return enable(options)
+
+
+def get_enabled_services():
+    services = enabled_services()
+    return [s.name for s in services.enabled_services]
+
+
+def attach_sub(token, enable_services=None, auto_enable=False):
+    if enable_services:
+        options = FullTokenAttachOptions(token=token, auto_enable_services=False)
+        res = full_token_attach(options)
+        for service in enable_services:
+            enable_service(service=service)
+        return res
+    options = FullTokenAttachOptions(token=token, auto_enable_services=auto_enable)
+    return full_token_attach(options)

--- a/src/pro_client.py
+++ b/src/pro_client.py
@@ -1,3 +1,8 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Pro client api related functions."""
+
 from uaclient.api.u.pro.attach.token.full_token_attach.v1 import (
     FullTokenAttachOptions,
     full_token_attach,
@@ -7,35 +12,51 @@ from uaclient.api.u.pro.services.enable.v1 import EnableOptions, enable
 from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
 from uaclient.api.u.pro.status.is_attached.v1 import is_attached
 
-from exceptions import ProcessExecutionError
+from exceptions import APIError
 from utils import retry
 
 
 # Add error handling to all functions
 def attach_status():
-    return is_attached().is_attached
+    """Check if system is attached to Ubuntu Pro subscription."""
+    res = is_attached()
+    if res.get("errors", None):
+        raise APIError(error_code=res["errors"][0]["code"], message=res["errors"][0]["title"])
+    return res.is_attached
 
 
 def detach_sub():
-    return detach()
+    """Detach system from Ubuntu Pro subscription."""
+    res = detach()
+    if res.get("errors", None):
+        raise APIError(error_code=res["errors"][0]["code"], message=res["errors"][0]["title"])
+    return res
 
 
 def enable_service(service):
+    """Enable a specific Ubuntu Pro service."""
     options = EnableOptions(service=service)
-    return enable(options)
+    res = enable(options)
+    if res.get("errors", None):
+        raise APIError(error_code=res["errors"][0]["code"], message=res["errors"][0]["title"])
+    return res
 
 
 def get_enabled_services():
+    """Get list of enabled Ubuntu Pro services."""
     services = enabled_services()
     return [s.name for s in services.enabled_services]
 
 
+@retry(APIError)
 def attach_sub(token, enable_services=None, auto_enable=False):
+    """Attach system to Ubuntu Pro subscription using token."""
+    auto_enable_setting = False if enable_services else auto_enable
+    options = FullTokenAttachOptions(token=token, auto_enable_services=auto_enable_setting)
+    res = full_token_attach(options)
+    if res.get("errors", None):
+        raise APIError(error_code=res["errors"][0]["code"], message=res["errors"][0]["title"])
     if enable_services:
-        options = FullTokenAttachOptions(token=token, auto_enable_services=False)
-        res = full_token_attach(options)
         for service in enable_services:
             enable_service(service=service)
-        return res
-    options = FullTokenAttachOptions(token=token, auto_enable_services=auto_enable)
-    return full_token_attach(options)
+    return res

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,8 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utility functions init file."""
+
 from utils.retry import retry
 from utils.util import parse_services, update_configuration
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,4 @@
+from utils.retry import retry
+from utils.util import parse_services, update_configuration
+
+__all__ = ["retry", "update_configuration", "parse_services"]

--- a/src/utils/util.py
+++ b/src/utils/util.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utility functions for the Ubuntu Pro charm."""
+
+
+import yaml
+
+
+def update_configuration(contract_url):
+    """Write the contract_url to the uaclient configuration file."""
+    with open("/etc/ubuntu-advantage/uaclient.conf", "r+") as f:
+        client_config = yaml.safe_load(f)
+        client_config["contract_url"] = contract_url
+        f.seek(0)
+        yaml.dump(client_config, f)
+        f.truncate()
+
+
+def parse_services(services_str):
+    """Parse a comma-separated string of services into a list."""
+    return (
+        [service.strip() for service in services_str.split(",") if service.strip() != ""]
+        if services_str and services_str.strip() != ""
+        else None
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Pytest configuration."""
+
+# tests/conftest.py
+import sys
+from pathlib import Path
+
+src_dir = Path(__file__).parent.parent / "src"
+sys.path.append(str(src_dir))
+sys.path.append(str("lib"))

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,8 +33,11 @@ async def test_attach_invalid_token(ops_test: OpsTest):
     await charm.set_config({"token": "new-token-2"})
     await ops_test.model.wait_for_idle()
 
+    expected_error = "Failed running command '['ubuntu-advantage', 'attach', 'new-token-2']' \
+[exit status: 1].\nstderr: Invalid token. See https://ubuntu.com/pro/dashboard\n\nstdout: "
     unit = charm.units[0]
     assert unit.workload_status == BlockedStatus.name
+    assert unit.workload_status_message == expected_error
 
 
 async def test_attach_services(ops_test: OpsTest):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,8 +33,7 @@ async def test_attach_invalid_token(ops_test: OpsTest):
     await charm.set_config({"token": "new-token-2"})
     await ops_test.model.wait_for_idle()
 
-    expected_error = "Failed running command '['ubuntu-advantage', 'attach', 'new-token-2']' \
-[exit status: 1].\nstderr: Invalid token. See https://ubuntu.com/pro/dashboard\n\nstdout: "
+    expected_error = "Invalid token. See https://ubuntu.com/pro/dashboard"
     unit = charm.units[0]
     assert unit.workload_status == BlockedStatus.name
     assert unit.workload_status_message == expected_error
@@ -47,7 +46,7 @@ async def test_attach_services(ops_test: OpsTest):
     charm = ops_test.model.applications["ubuntu-advantage"]
 
     # Attach to pro subscription with services
-    await charm.set_config({"services": "esm-infra,cis", "token": f"{test_token}"})
+    await charm.set_config({"services": "esm-infra,usg", "token": f"{test_token}"})
     await ops_test.model.wait_for_idle()
 
     unit = charm.units[0]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import os
+
 import pytest
 from ops.model import ActiveStatus, BlockedStatus
 from pytest_operator.plugin import OpsTest
@@ -29,6 +31,84 @@ async def test_attach_invalid_token(ops_test: OpsTest):
     await ops_test.model.wait_for_idle()
 
     await charm.set_config({"token": "new-token-2"})
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_attach_services(ops_test: OpsTest):
+    # Set test token to environment variable PRO_CHARM_TEST_TOKEN
+    # bash: export PRO_CHARM_TEST_TOKEN="your-token"
+    test_token = os.environ.get("PRO_CHARM_TEST_TOKEN")
+    charm = ops_test.model.applications["ubuntu-advantage"]
+
+    # Attach to pro subscription with services
+    await charm.set_config({"services": "esm-infra,cis", "token": f"{test_token}"})
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == ActiveStatus.name
+    assert unit.workload_status_message == "Attached (esm-infra,usg)"
+
+    # Detach from pro subscription
+    await charm.set_config({"token": "", "services": ""})
+    await ops_test.model.wait_for_idle()
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_empty_livepatch_config(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    test_token = os.environ.get("PRO_CHARM_TEST_TOKEN")
+
+    await charm.set_config({"token": test_token, "livepatch_token": ""})
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == ActiveStatus.name
+
+    # Detach from pro subscription
+    await charm.set_config({"token": ""})
+    await ops_test.model.wait_for_idle()
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_livepatch_server_success(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    test_pro_token = os.environ.get("PRO_CHARM_TEST_TOKEN")
+    test_livepatch_token = os.environ.get("PRO_CHARM_TEST_LIVEPATCH_STAGING_TOKEN")
+
+    await charm.set_config(
+        {
+            "livepatch_server_url": "https://livepatch.staging.canonical.com",
+            "livepatch_token": test_livepatch_token,
+            "token": test_pro_token,
+        }
+    )
+    await ops_test.model.wait_for_idle()
+
+    unit = charm.units[0]
+    assert unit.workload_status == ActiveStatus.name
+
+    # Detach from pro subscription and livepatch
+    await charm.set_config({"token": "", "livepatch_token": "", "livepatch_server_url": ""})
+    await ops_test.model.wait_for_idle()
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_livepatch_server_set_fails(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    await charm.set_config(
+        {"livepatch_server_url": "https://www.example.com", "livepatch_token": "new-token"}
+    )
+    await ops_test.model.wait_for_idle()
+    unit = charm.units[0]
+    assert unit.workload_status == BlockedStatus.name
+
+
+async def test_detach_subscription(ops_test: OpsTest):
+    charm = ops_test.model.applications["ubuntu-advantage"]
+    await charm.set_config({"token": ""})
     await ops_test.model.wait_for_idle()
 
     unit = charm.units[0]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,16 +2,16 @@
 # See LICENSE file for licensing details.
 
 import json
-from subprocess import PIPE, CalledProcessError
+from subprocess import CalledProcessError
 from textwrap import dedent
 from unittest import TestCase
-from unittest.mock import ANY, MagicMock, call, mock_open, patch
+from unittest.mock import call, mock_open, patch
 
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 from charm import UbuntuAdvantageCharm
-from exceptions import ProcessExecutionError
+from exceptions import APIError
 
 STATUS_ATTACHED = json.dumps(
     {
@@ -60,17 +60,17 @@ class TestCharm(TestCase):
         self.mocks = {
             "call": patch("subprocess.call").start(),
             "check_call": patch("subprocess.check_call").start(),
-            "run": patch("subprocess.run").start(),
             "open": patch("builtins.open").start(),
             "environ": patch.dict("os.environ", clear=True).start(),
             "apt": patch("charm.apt").start(),
-            "status_output": patch("charm.get_status_output").start(),
             "install_livepatch": patch("charm.install_livepatch").start(),
             "disable_livepatch": patch("charm.disable_canonical_livepatch").start(),
+            "attach_status": patch("charm.attach_status").start(),
+            "detach_sub": patch("charm.detach_sub").start(),
+            "enable_service": patch("charm.enable_service").start(),
+            "get_enabled_services": patch("charm.get_enabled_services").start(),
         }
         self.mocks["call"].return_value = 0
-        self.mocks["run"].return_value = MagicMock(returncode=0, stderr="")
-        self.mocks["status_output"].return_value = json.loads(STATUS_DETACHED)
         mock_open(self.mocks["open"], read_data=DEFAULT_CLIENT_CONFIG)
         self.harness = Harness(UbuntuAdvantageCharm)
         self.addCleanup(self.harness.cleanup)
@@ -205,15 +205,9 @@ class TestCharm(TestCase):
         self.assertTrue(self.harness.charm._state.package_needs_installing)
         self.assertIsInstance(self.harness.model.unit.status, MaintenanceStatus)
 
-    @patch("charm.attach_subscription", side_effect=[(0, "")])
-    @patch(
-        "charm.get_status_output",
-        side_effect=[
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_ATTACHED),
-        ],
-    )
-    def test_config_changed_token_unattached(self, m_get_status_output, m_attach_subscription):
+    @patch("charm.attach_sub", side_effect=[{"enabled": [], "reboot_required": False}])
+    @patch("charm.get_enabled_services", return_value=[])
+    def test_config_changed_token_unattached(self, m_enabled_services, m_attach_sub):
         self.harness.update_config({"token": "test-token"})
         self.mocks["open"].assert_called_with("/etc/ubuntu-advantage/uaclient.conf", "r+")
         handle = self.mocks["open"]()
@@ -227,31 +221,26 @@ class TestCharm(TestCase):
         )
         self.assertEqual(_written(handle), expected)
         handle.truncate.assert_called_once()
-        assert m_get_status_output.call_count == 2
-        assert m_attach_subscription.call_count == 1
+        assert m_attach_sub.call_count == 1
         self.assertEqual(
             self.harness.charm._state.hashed_token,
             "4c5dc9b7708905f77f5e5d16316b5dfb425e68cb326dcd55a860e90a7707031e",
         )
-        self.assertEqual(
-            self.harness.model.unit.status, ActiveStatus("Attached (esm-apps,esm-infra,livepatch)")
-        )
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus("Attached ()"))
 
-    @patch("charm.attach_subscription", side_effect=[(0, ""), (0, "")])
     @patch(
-        "charm.get_status_output",
+        "charm.attach_sub",
         side_effect=[
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
+            {"enabled": [], "reboot_required": False},
+            {"enabled": [], "reboot_required": False},
         ],
     )
-    def test_config_changed_token_reattach(self, m_get_status_output, m_attach_subscription):
+    @patch("charm.get_enabled_services", return_value=[])
+    @patch("charm.attach_status", side_effect=[False, True])
+    def test_config_changed_token_reattach(
+        self, m_attach_status, m_enabled_services, m_attach_sub
+    ):
         self.harness.update_config({"token": "test-token"})
-        self.assertEqual(self.mocks["check_call"].call_count, 2)
         self._assert_apt_calls()
         self.mocks["open"].assert_called_with("/etc/ubuntu-advantage/uaclient.conf", "r+")
         self._assert_apt_calls()
@@ -266,8 +255,9 @@ class TestCharm(TestCase):
         )
         self.assertEqual(_written(handle), expected)
         handle.truncate.assert_called_once()
-        assert m_get_status_output.call_count == 2
-        assert m_attach_subscription.call_count == 1
+        assert m_attach_status.call_count == 1
+        assert m_attach_sub.call_count == 1
+        assert m_enabled_services.call_count == 1
         self.assertEqual(
             self.harness.charm._state.hashed_token,
             "4c5dc9b7708905f77f5e5d16316b5dfb425e68cb326dcd55a860e90a7707031e",
@@ -275,82 +265,92 @@ class TestCharm(TestCase):
 
         self.mocks["check_call"].reset_mock()
         self.harness.update_config({"token": "test-token-2"})
-        self.assertEqual(self.mocks["check_call"].call_count, 3)
-        self.mocks["check_call"].assert_has_calls(
-            self._add_ua_proxy_setup_calls(
-                [call(["ubuntu-advantage", "detach", "--assume-yes"], env=ANY)], append=False
-            )
-        )
-        assert m_get_status_output.call_count == 4
-        assert m_attach_subscription.call_count == 2
+        self.assertEqual(self.mocks["check_call"].call_count, 2)
+
+        assert m_attach_status.call_count == 2
+        assert m_attach_sub.call_count == 2
+        assert m_enabled_services.call_count == 2
         self.assertEqual(
             self.harness.charm._state.hashed_token,
             "ab8a83efb364bf3f6739348519b53c8e8e0f7b4c06b6eeb881ad73dcf0059107",
         )
-        self.assertEqual(
-            self.harness.model.unit.status, ActiveStatus("Attached (esm-apps,esm-infra,livepatch)")
-        )
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus("Attached ()"))
 
     @patch(
-        "charm.get_status_output",
+        "charm.attach_status",
         side_effect=[
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_ATTACHED),
+            False,
+            True,
         ],
     )
-    def test_attach_retry_on_failure(self, m_get_status_output):
-        self.mocks["run"].side_effect = [
-            MagicMock(returncode=0, stderr=""),
-            ProcessExecutionError("attach", 1, "", "Invalid token"),
-            MagicMock(returncode=0, stderr=""),
-        ]
+    @patch(
+        "pro_client.full_token_attach",
+        side_effect=[
+            {"errors": [{"code": "attach-invalid-token", "title": "Invalid token."}]},
+            {"enabled_services": [], "reboot_required": False},
+        ],
+    )
+    @patch("charm.get_enabled_services", return_value=[])
+    def test_attach_retry_on_failure(
+        self, m_enabled_services, m_full_token_attach, m_attach_status
+    ):
+        # Retries once and then passes
+        # Only simulating if any errors are raised, a retry mechanism is called
+        # and if one retry passes, we are attached
+        from pro_client import FullTokenAttachOptions
+
         self.harness.update_config({"token": "test-token"})
-        self.assertEqual(self.mocks["run"].call_count, 1)
-        self.assertEqual(m_get_status_output.call_count, 2)
-        self.assertEqual(
-            self.harness.model.unit.status, ActiveStatus("Attached (esm-apps,esm-infra,livepatch)")
+        m_full_token_attach.assert_has_calls(
+            [
+                call(FullTokenAttachOptions(token="test-token", auto_enable_services=True)),
+            ]
         )
+        assert m_full_token_attach.call_count == 2
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus("Attached ()"))
 
     @patch(
-        "charm.attach_subscription",
-        side_effect=[ProcessExecutionError("attach", 1, "", "Invalid token")],
+        "charm.attach_sub",
+        side_effect=[APIError("attach-invalid-token", "Invalid token.")],
     )
     def test_config_changed_attach_failure(self, m_attach_subscription):
         self.harness.update_config({"token": "test-token"})
-        assert self.mocks["status_output"].call_count == 1
         assert m_attach_subscription.call_count == 1
-        message = (
-            "Failed running command 'attach' [exit status: 1].\nstderr: Invalid token\nstdout: "
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Error code: attach-invalid-token, message: Invalid token."),
         )
-        self.assertEqual(self.harness.model.unit.status, BlockedStatus(message))
 
-    @patch("charm.parse_services")
-    @patch("charm.create_attach_config")
-    def test_attach_with_added_services(self, m_create_attach_config, m_parse_services):
-        m_parse_services.return_value = ["esm-infra", "fips"]
-        m_create_attach_config.return_value.__enter__.return_value = "/tmp/mock_attach.yaml"
-        self.harness.update_config({"token": "test-token", "services": "esm-infra, fips"})
-
-        m_parse_services.assert_called_once_with("esm-infra, fips")
-        assert m_create_attach_config.call_count == 1
-
-    @patch("charm.attach_subscription", return_value=(0, ""))
-    def test_attach_with_no_services(self, m_attach_subscription):
+    @patch("charm.attach_sub", return_value=(0, ""))
+    def test_attach_with_no_services(self, m_attach_sub):
         self.harness.update_config({"token": "test-token"})
-        m_attach_subscription.assert_called_once_with("test-token", ANY, services=None)
+        m_attach_sub.assert_called_once_with("test-token", None, auto_enable=True)
 
     @patch(
-        "charm.get_status_output",
+        "pro_client.full_token_attach",
         side_effect=[
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
+            {"enabled_services": [], "reboot_required": False},
         ],
     )
-    @patch("charm.attach_subscription", side_effect=[(0, "")])
-    def test_config_changed_token_detach(self, m_attach_subscription, m_get_status_output):
+    @patch("pro_client.enable_service")
+    def test_attach_with_added_services(self, m_enable_service, m_full_token_attach):
+        from pro_client import FullTokenAttachOptions
+
+        self.harness.update_config({"token": "test-token", "services": "fips"})
+        m_full_token_attach.assert_has_calls(
+            [
+                call(FullTokenAttachOptions(token="test-token", auto_enable_services=False)),
+            ]
+        )
+        assert m_enable_service.call_count == 1
+        m_enable_service.assert_called_once_with(service="fips")
+
+    @patch(
+        "charm.attach_status",
+        side_effect=[False, True],
+    )
+    @patch("charm.attach_sub")
+    @patch("charm.detach_sub")
+    def test_config_changed_token_detach(self, m_detach_sub, m_attach_sub, m_get_status_output):
         self.harness.update_config({"token": "test-token"})
         self.assertEqual(
             self.harness.charm._state.hashed_token,
@@ -359,56 +359,25 @@ class TestCharm(TestCase):
 
         self.mocks["check_call"].reset_mock()
         self.harness.update_config({"token": ""})
-        self.assertEqual(self.mocks["check_call"].call_count, 3)
-        self.mocks["check_call"].assert_has_calls(
-            self._add_ua_proxy_setup_calls(
-                [call(["ubuntu-advantage", "detach", "--assume-yes"], env=ANY)], append=False
-            )
-        )
-        assert m_get_status_output.call_count == 3
-        assert m_attach_subscription.call_count == 1
+
+        assert m_detach_sub.call_count == 1
+        assert m_attach_sub.call_count == 1
         self.assertIsNone(self.harness.charm._state.hashed_token)
         self.assertEqual(self.harness.model.unit.status, BlockedStatus("No token configured"))
 
-    @patch("charm.attach_subscription", side_effect=[(0, "")])
+    @patch("charm.attach_sub")
     @patch(
-        "charm.get_status_output",
-        side_effect=[
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_ATTACHED),
-        ],
+        "charm.attach_status",
+        side_effect=[False, True],
     )
-    def test_config_changed_token_update_after_block(
-        self, m_get_status_output, m_attach_subscription
-    ):
+    def test_config_changed_token_update_after_block(self, m_attach_status, m_attach_sub):
         self.harness.update_config()
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
         self.harness.update_config({"token": "test-token"})
-        assert m_get_status_output.call_count == 3
-        assert m_attach_subscription.call_count == 1
+        assert m_attach_status.call_count == 2
+        assert m_attach_sub.call_count == 1
         self.assertIsInstance(self.harness.model.unit.status, ActiveStatus)
-
-    @patch("charm.attach_subscription", side_effect=[(0, "")])
-    @patch(
-        "charm.get_status_output",
-        side_effect=[
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_ATTACHED),
-        ],
-    )
-    def test_config_changed_token_contains_newline(
-        self, m_get_status_output, m_attach_subscription
-    ):
-        self.harness.update_config({"token": "test-token\n"})
-        self.assertEqual(
-            self.harness.charm._state.hashed_token,
-            "4c5dc9b7708905f77f5e5d16316b5dfb425e68cb326dcd55a860e90a7707031e",
-        )
-        assert m_get_status_output.call_count == 2
-        assert m_attach_subscription.call_count == 1
 
     def test_config_changed_ppa_contains_newline(self):
         self.harness.update_config({"ppa": "ppa:ua-client/stable\n"})
@@ -418,23 +387,6 @@ class TestCharm(TestCase):
             ]
         )
         self.assertEqual(self.harness.charm._state.ppa, "ppa:ua-client/stable")
-        assert self.mocks["status_output"].call_count == 1
-
-    @patch("charm.attach_subscription", side_effect=[(0, "")])
-    @patch(
-        "charm.get_status_output",
-        side_effect=[
-            json.loads(bytes(STATUS_DETACHED, "utf-8")),
-            json.loads(bytes(STATUS_ATTACHED, "utf-8")),
-        ],
-    )
-    def test_config_changed_check_output_returns_bytes(
-        self, m_get_status_output, m_attach_subscription
-    ):
-        self.harness.update_config({"token": "test-token"})
-        self.assertEqual(
-            self.harness.model.unit.status, ActiveStatus("Attached (esm-apps,esm-infra,livepatch)")
-        )
 
     def test_config_changed_contract_url(self):
         self.harness.update_config({"contract_url": "https://contracts.staging.canonical.com"})
@@ -450,26 +402,30 @@ class TestCharm(TestCase):
         )
         self.assertEqual(_written(handle), expected)
         handle.truncate.assert_called_once()
-        assert self.mocks["status_output"].call_count == 1
         self.assertEqual(
             self.harness.charm._state.contract_url, "https://contracts.staging.canonical.com"
         )
 
-    @patch("charm.attach_subscription", side_effect=[(0, ""), (0, "")])
+    @patch("charm.detach_sub")
     @patch(
-        "charm.get_status_output",
+        "charm.attach_sub",
         side_effect=[
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
-            json.loads(STATUS_ATTACHED),
+            {"enabled_services": [], "reboot_required": False},
+            {"enabled_services": [], "reboot_required": False},
+        ],
+    )
+    @patch(
+        "charm.attach_status",
+        side_effect=[
+            False,
+            True,
+            True,
         ],
     )
     def test_config_changed_contract_url_reattach(
-        self, m_get_status_output, m_attach_subscription
+        self, m_attach_status, m_attach_sub, m_detach_sub
     ):
+        # TODO: Update
         self.harness.update_config({"token": "test-token"})
         self.assertEqual(
             self.harness.charm._state.hashed_token,
@@ -491,29 +447,25 @@ class TestCharm(TestCase):
         )
         self.assertEqual(_written(handle), expected)
         handle.truncate.assert_called_once()
-        self.mocks["check_call"].assert_has_calls(
-            [call(["ubuntu-advantage", "detach", "--assume-yes"], env=ANY)]
-        )
-        self.assertEqual(
-            self.harness.model.unit.status, ActiveStatus("Attached (esm-apps,esm-infra,livepatch)")
-        )
+        assert m_detach_sub.call_count == 1
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus("Attached ()"))
 
         self.mocks["check_call"].reset_mock()
         self.mocks["open"].reset_mock()
         mock_open(self.mocks["open"], read_data=DEFAULT_CLIENT_CONFIG)
         self.harness.update_config()
         self.mocks["open"].assert_not_called()
-        assert m_get_status_output.call_count == 6
-        assert m_attach_subscription.call_count == 2
+        assert m_attach_status.call_count == 3
+        assert m_attach_sub.call_count == 2
 
     @patch(
-        "charm.get_status_output",
+        "charm.attach_status",
         side_effect=[
-            json.loads(STATUS_DETACHED),
-            json.loads(STATUS_ATTACHED),
+            False,
+            True,
         ],
     )
-    def test_config_changed_unset_contract_url(self, m_get_status_output):
+    def test_config_changed_unset_contract_url(self, m_attach_status):
         self.harness.update_config({"contract_url": "https://contracts.staging.canonical.com"})
         self.mocks["open"].assert_called_with("/etc/ubuntu-advantage/uaclient.conf", "r+")
         handle = self.mocks["open"]()
@@ -543,7 +495,7 @@ class TestCharm(TestCase):
             log_level: debug
         """
         )
-        assert m_get_status_output.call_count == 2
+        assert m_attach_status.call_count == 2
         self.assertEqual(_written(handle), expected)
         handle.truncate.assert_called_once()
         self.mocks["call"].assert_not_called()
@@ -593,30 +545,33 @@ class TestCharm(TestCase):
             ]
         )
 
-    def test_config_changed_set_ssl_cert_file_override(self):
-        # Set proxy override once.
-        self.harness.update_config(
-            {
-                "override-ssl-cert-file": "/etc/ssl/certs/ca-certificates.crt",
-            }
-        )
-        self.mocks["run"].reset_mock()
-        self.harness.update_config(
-            {
-                "token": "token",
-            }
-        )
-        self.mocks["run"].assert_has_calls(
-            [
-                call(
-                    ["ubuntu-advantage", "attach", "token"],
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    env={"SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt"},
-                ),
-            ]
-        )
-        self.mocks["run"].reset_mock()
+    # Commented out until we can figure out if we can set certification files
+    # for the pro client api
+    #
+    # def test_config_changed_set_ssl_cert_file_override(self):
+    #     # Set proxy override once.
+    #     self.harness.update_config(
+    #         {
+    #             "override-ssl-cert-file": "/etc/ssl/certs/ca-certificates.crt",
+    #         }
+    #     )
+    #     self.mocks["run"].reset_mock()
+    #     self.harness.update_config(
+    #         {
+    #             "token": "token",
+    #         }
+    #     )
+    #     self.mocks["run"].assert_has_calls(
+    #         [
+    #             call(
+    #                 ["ubuntu-advantage", "attach", "token"],
+    #                 stdout=PIPE,
+    #                 stderr=PIPE,
+    #                 env={"SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt"},
+    #             ),
+    #         ]
+    #     )
+    #     self.mocks["run"].reset_mock()
 
     @patch("charm.set_livepatch_server", side_effect=[(0, "")])
     @patch("charm.enable_livepatch_server", side_effect=[(0, "")])
@@ -631,10 +586,12 @@ class TestCharm(TestCase):
     @patch("charm.get_enabled_services", side_effect=[["esm-apps", "esm-infra", "livepatch"]])
     @patch("charm.set_livepatch_server", side_effect=[(0, ""), (0, "")])
     @patch("charm.enable_livepatch_server", side_effect=[(0, "")])
-    @patch("charm.get_status_output", return_value=json.loads(STATUS_ATTACHED))
+    @patch("charm.attach_status", return_value=True)
+    @patch("charm.enable_service")
     def test_canonical_livepatch_unset_server_livepatch_enabled(
         self,
-        m_get_status_output,
+        m_enable_service,
+        m_attach_status,
         m_enable_livepatch_server,
         m_set_livepatch_server,
         m_get_enabled_services,
@@ -649,9 +606,8 @@ class TestCharm(TestCase):
         self.assertEqual(m_enable_livepatch_server.call_count, 1)
         self.assertEqual(m_set_livepatch_server.call_count, 2)
         self.assertEqual(m_get_enabled_services.call_count, 1)
-        self.mocks["check_call"].assert_has_calls(
-            [call(["ubuntu-advantage", "enable", "livepatch"], env=ANY)]
-        )
+        self.assertEqual(m_enable_service.call_count, 1)
+        m_enable_service.assert_called_once_with("livepatch")
 
     @patch("charm.get_enabled_services", side_effect=[[]])
     @patch("charm.set_livepatch_server", side_effect=[(0, ""), (0, "")])

--- a/tox.ini
+++ b/tox.ini
@@ -60,8 +60,11 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
+pythonbase = python3.12
 deps =
     pytest
+    git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/noble-updates
+    git+https://github.com/canonical/ubuntu-pro-client.git
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ passenv =
   HTTP_PROXY
   HTTPS_PROXY
   NO_PROXY
+  PRO_CHARM_TEST_TOKEN
+  PRO_CHARM_TEST_LIVEPATCH_STAGING_TOKEN
 
 [testenv:fmt]
 description = Apply coding style standards to code

--- a/tox.ini
+++ b/tox.ini
@@ -72,9 +72,16 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju>=3.5.2.0
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+
+[testenv:pack-24.04]
+description = Link charmcraft-24.04.yaml to charmcraft.yaml, pack and restore
+allowlist_externals =
+    sh
+commands =
+    sh -c "ln -srf {toxinidir}/charmcraft-24.04.yaml {toxinidir}/charmcraft.yaml && charmcraft pack --project-dir={toxinidir}; ln -srf {toxinidir}/charmcraft-22.04.yaml {toxinidir}/charmcraft.yaml"


### PR DESCRIPTION
This PR updates the charm to utilize the pro-client API for managing subscription attachment/detachment and fetching service-related information. 

Primary motive is to enhance code readability, and maintainability while making sure pro-client functionality aligns with pro-client API standards. Also improves error catching due to use of API.

- Refactored charm code into easy to identify modules
- Eliminated sub-process calls to instead use the pro-client API
- Updated unit tests

### Prerequisite 

Need to merge #2 before merging this as all changes are based upon it. 