### PR TITLE
Don't print secrets on errors

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,9 @@ def enable_livepatch_server(token):
             else result.stderr
         )
         logger.error("Error running canonical-livepatch enable: %s", stderr)
-        raise ProcessExecutionError(result.args, result.returncode, stdout, stderr)
+        raise ProcessExecutionError(
+            "canonical-livepatch enable $TOKEN", result.returncode, stdout, stderr
+        )
 
 
 def install_livepatch():
@@ -155,17 +157,9 @@ def create_attach_config(token, services=None):
 @retry(ProcessExecutionError)
 def attach_subscription(token, env, services=None):
     """Attach an ubuntu-advantage subscription using the specified token and services."""
-    if services:
-        with create_attach_config(token, services) as attach_config_path:
-            result = subprocess.run(
-                ["ubuntu-advantage", "attach", "--attach-config", attach_config_path],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-            )
-    else:
+    with create_attach_config(token, services) as attach_config_path:
         result = subprocess.run(
-            ["ubuntu-advantage", "attach", token],
+            ["ubuntu-advantage", "attach", "--attach-config", attach_config_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -609,7 +609,7 @@ class TestCharm(TestCase):
         self.mocks["run"].assert_has_calls(
             [
                 call(
-                    ["ubuntu-advantage", "attach", "token"],
+                    ["ubuntu-advantage", "attach", "--attach-config", ANY],
                     stdout=PIPE,
                     stderr=PIPE,
                     env={"SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt"},


### PR DESCRIPTION
All in the title - this one's pretty simple.
The only interesting bit is that we now always use the attach-config method of attaching.