### PR TITLE
Fix name in Usage section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Be sure to replace `<token>` with a valid value from
 
 ```
 juju deploy ubuntu
-juju deploy ubuntu-advantage --config token=<token>
-juju add-relation ubuntu ubuntu-advantage
+juju deploy ubuntu-pro --config token=<token>
+juju add-relation ubuntu ubuntu-pro
 ```
 
 ## Development


### PR DESCRIPTION
Just a small fix for the README.md:
The usage section still used the old ubuntu-advantage name, instead of ubuntu-pro.
That's a bit confusing, because the section above it explicitly states that that is deprecated.